### PR TITLE
Antenna selection CLI argument (an interface to s/nchan)

### DIFF
--- a/rawspec.c
+++ b/rawspec.c
@@ -87,7 +87,7 @@ void usage(const char *argv0) {
     "Usage: %s [options] STEM [...]\n"
     "\n"
     "Options:\n"
-    "  -a, --ant=ANT          The 0-indexed antenna to exclusively process\n"
+    "  -a, --ant=ANT          The 0-indexed antenna to exclusively process [-1]\n"
     "  -d, --dest=DEST        Destination directory or host:port\n"
     "  -f, --ffts=N1[,N2...]  FFT lengths [1048576, 8, 1024]\n"
     "  -g, --GPU=IDX          Select GPU device to use [0]\n"
@@ -512,8 +512,8 @@ char tmp[16];
         // If processing a specific antenna
         if(ant != -1) {
           // Validate ant
-          if(ant > raw_hdr.nants - 1) {
-            printf("bad antenna selection: ant > nants (%u > %d)\n",
+          if(ant > raw_hdr.nants - 1 || ant < 0) {
+            printf("bad antenna selection: ant <> {0, nants} (%u <> {0, %d})\n",
                 ant, raw_hdr.nants);
             close(fdin);
             break; // Goto next stem

--- a/rawspec.c
+++ b/rawspec.c
@@ -151,7 +151,7 @@ char tmp[16];
   int next_stem = 0;
   int save_headers = 0;
   unsigned int Nc;   // Number of coarse channels across the observation (possibly multi-antenna)
-  unsigned int NcAnt;// Number of coarse channels per antenna
+  unsigned int Ncpa;// Number of coarse channels per antenna
   unsigned int Np;   // Number of polarizations
   unsigned int Ntpb; // Number of time samples per block
   unsigned int Nbps; // Number of bits per sample
@@ -174,7 +174,7 @@ char tmp[16];
   rawspec_raw_hdr_t raw_hdr;
   callback_data_t cb_data[MAX_OUTPUTS];
   rawspec_context ctx;
-  int ant = 0;
+  int ant = -1;
   unsigned int schan = 0;
   unsigned int nchan = 0;
   unsigned int outidx = 0;
@@ -478,7 +478,7 @@ char tmp[16];
 
         // Calculate Ntpb and validate block dimensions
         Nc = raw_hdr.obsnchan;
-        NcAnt = raw_hdr.obsnchan/raw_hdr.nants;
+        Ncpa = raw_hdr.obsnchan/raw_hdr.nants;
         Np = raw_hdr.npol;
         Nbps = raw_hdr.nbits;
         Ntpb = raw_hdr.blocsize / (2 * Np * Nc * (Nbps/8));
@@ -512,17 +512,17 @@ char tmp[16];
         // If processing a specific antenna
         if(ant != -1) {
           // Validate ant
-          if(ant > raw_hdr.nants) {
+          if(ant > raw_hdr.nants - 1) {
             printf("bad antenna selection: ant > nants (%u > %d)\n",
                 ant, raw_hdr.nants);
             close(fdin);
             break; // Goto next stem
           }
 
-          // Set Nc to NcAnt and skip previous antennas
-          printf("Selection of antenna %d equates to a starting channel of %d\n", ant, ant*NcAnt);
-          schan += ant * NcAnt;
-          Nc = NcAnt;
+          // Set Nc to Ncpa and skip previous antennas
+          printf("Selection of antenna %d equates to a starting channel of %d\n", ant, ant*Ncpa);
+          schan += ant * Ncpa;
+          Nc = Ncpa;
         }
 
         // If processing a subset of coarse channels
@@ -537,9 +537,9 @@ char tmp[16];
             break; // Goto next stem
           }
           else if(ant != -1 && // antenna selection
-            (nchan != 0 && nchan > NcAnt)) {
+            (nchan != 0 && nchan > Ncpa)) {
             printf("bad channel range: nchan > antnchan {obsnchan/nants} (%u > %d {%d/%d})\n",
-                nchan, NcAnt, raw_hdr.obsnchan, raw_hdr.nants);
+                nchan, Ncpa, raw_hdr.obsnchan, raw_hdr.nants);
             close(fdin);
             break; // Goto next stem
           }

--- a/rawspec.c
+++ b/rawspec.c
@@ -518,6 +518,13 @@ char tmp[16];
             close(fdin);
             break; // Goto next stem
           }
+          if(schan >= Ncpa) {
+            printf("bad schan specification with antenna selection: "
+                   "schan > antnchan {obsnchan/nants} (%u > %u {%d/%d})\n",
+                schan, Ncpa, raw_hdr.obsnchan, raw_hdr.nants);
+            close(fdin);
+            break; // Goto next stem
+          }
 
           // Set Nc to Ncpa and skip previous antennas
           printf("Selection of antenna %d equates to a starting channel of %d\n", ant, ant*Ncpa);
@@ -529,7 +536,7 @@ char tmp[16];
         if(nchan != 0) {
           // Validate schan and nchan
           if(ant == -1 && // no antenna selection
-              (nchan != 0 && schan + nchan > Nc)) {
+              (schan + nchan > Nc)) {
 
             printf("bad channel range: schan + nchan > obsnchan (%u + %u > %d)\n",
                 schan, nchan, raw_hdr.obsnchan);
@@ -537,9 +544,9 @@ char tmp[16];
             break; // Goto next stem
           }
           else if(ant != -1 && // antenna selection
-            (nchan != 0 && nchan > Ncpa)) {
-            printf("bad channel range: nchan > antnchan {obsnchan/nants} (%u > %d {%d/%d})\n",
-                nchan, Ncpa, raw_hdr.obsnchan, raw_hdr.nants);
+                 (schan + nchan > (ant + 1) * Ncpa)) {
+            printf("bad channel range: schan + nchan > antnchan {obsnchan/nants} (%u + %u > %d {%d/%d})\n",
+                schan - ant * Ncpa, nchan, Ncpa, raw_hdr.obsnchan, raw_hdr.nants);
             close(fdin);
             break; // Goto next stem
           }


### PR DESCRIPTION
As per #6 this enables selective processing of a single antenna's data.

Verified with a block where only 1 of 4 antenna had non-zero data. The data was random, so no verification of integrity was achieved. Until a more thorough verification, this will remain a draft.