### PR TITLE
Small Makefile Changes/Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@ DATADIR = $(PREFIX)/share
 CUDA_DIR ?= /usr/local/cuda-8.0
 CUDA_PATH ?= $(CUDA_DIR)
 
-CC=gcc
-HOST_COMPILER ?= $(CC)
+CC            ?= gcc
+CXX           ?= g++
+HOST_COMPILER ?= $(CXX)
 NVCC          := $(CUDA_PATH)/bin/nvcc -ccbin $(HOST_COMPILER)
 
 CFLAGS = -ggdb -fPIC
@@ -85,7 +86,7 @@ fileiotest: fileiotest.o
 rawspec_fbutils: rawspec_fbutils.c rawspec_fbutils.h
 	$(CC) -o $@ -DFBUTILS_TEST -ggdb -O0 $< -lm
 
-install: rawspec.h librawspec.so
+install: rawspec rawspec.h librawspec.so
 	mkdir -p $(BINDIR)
 	cp -p rawspec $(BINDIR)
 	mkdir -p $(INCDIR)


### PR DESCRIPTION
Hey Dave,

I came across a few oddities in the rawspec Makefile while trying to debug some other issues I was having, this PR contains 3 noticeable changes that fixed those oddities for me. Let me know if there's anyhting you want me to change or remove from the PR.

- The install target now requires the rawspec executable to be built before it will try to install it 
  - Previously, the install failed as the file was not found
- The CC variable will now respect environment variable, and only default back to GCC in the case that $CC is not set
  - Previously, this was overwriting any $CC environment variables, which caused issues for me as my default GCC install is too new for the Nvidia CUDA compiler
- Introduced a default value for CXX and swapped HOST_COMPILER to use it
  - NVCC needs a C++ capable compiler, or libcxx linked, in order to link CUDA code, gcc was raising errors here until g++ was used

Cheers,
David