### PR TITLE
Modify some calls to allow for FIFO support

### DIFF
--- a/rawspec_fbutils.c
+++ b/rawspec_fbutils.c
@@ -555,7 +555,15 @@ int fb_telescope_id(const char *telescope_name)
     id=8;
   else if (strcasecmp(telescope_name,"140FT")==0)
     id=9;
+  // ATA used to be 10, but the SRT is now 10 and (at leasst in bl_sigproc) ATA
+  // is 9.  The "140FT" telescope used to be 9 so we still map from that name
+  // to 9 even though bl_sigproc will display it as "ATA".  AFAIK, the 140FT is
+  // not producing GUPPI RAW files, so there is little chance that this will
+  // ever cause any problems (but it would still be nice to reconcile
+  // telescope_id across all sigproc-derived libraries).
   else if (strcasecmp(telescope_name,"ATA")==0)
+    id=9;
+  else if (strcasecmp(telescope_name,"SRT")==0)
     id=10;
   else if (strcasecmp(telescope_name,"LEUSCHNER")==0)
     id=11;

--- a/rawspec_gpu.cu
+++ b/rawspec_gpu.cu
@@ -1134,7 +1134,7 @@ int rawspec_start_processing(rawspec_context * ctx, int fft_dir)
 
       // Add FFT to stream
       cufft_rc = cufftExecC2C(plan,
-                              ((cufftComplex *)gpu_ctx->d_fft_in) + p * (ctx->Nbps/8),
+                              ((cufftComplex *)gpu_ctx->d_fft_in) + p,
                               gpu_ctx->d_fft_out + p * fft_outbuf_length,
                               fft_dir <= 0 ? CUFFT_INVERSE : CUFFT_FORWARD);
 

--- a/rawspec_rawutils.h
+++ b/rawspec_rawutils.h
@@ -6,6 +6,7 @@
 
 typedef struct {
   int directio;
+  int fifo;
   size_t blocsize;
   unsigned int npol;
   unsigned int obsnchan;
@@ -26,8 +27,12 @@ typedef struct {
   size_t hdr_size; // Size of header in bytes (not including DIRECTIO padding)
 } rawspec_raw_hdr_t;
 
+
+#define RAWSPEC_HEADER_ENTRY_LEN (80)
 // Multiple of 80 and 512
-#define MAX_RAW_HDR_SIZE (25600)
+#define MAX_RAW_HDR_SIZE (512 * RAWSPEC_HEADER_ENTRY_LEN)
+
+#define RAWPSEC_HEADER_END_KEY "END "
 
 #ifdef __cplusplus
 extern "C" {

--- a/rawspectest.c
+++ b/rawspectest.c
@@ -82,7 +82,7 @@ int main(int argc, char * argv[])
   ctx.h_blkbufs[ctx.Nb_host-1][(8*ctx.Np*2/*complex*/)*(ctx.Nbps/8)] = 127;
   // Set sample 9 of pol 1 to (0+1j), in block Nb_host-1
   // Note that for 16-bit samples, this will really be (0 + 127j/32767)
-  ctx.h_blkbufs[ctx.Nb_host-1][(9*ctx.Np*2/*complex*/+3)*(ctx.Nbps/8)] = 127;
+  ctx.h_blkbufs[ctx.Nb_host-1][(9*ctx.Np*2/*complex*/+3)*(ctx.Nbps/8)] = 64;
 
   // Salt the output buffers (to detect whether they are not fully written)
   for(i=0; i<ctx.No; i++) {


### PR DESCRIPTION
Hey Dave,

We've been looking to use FIFOs as an input to rawspec at the LOFAR stations given we're performing a packet-to-GUPPI raw conversion, so preventing a write to disk would save a good chunk of time while processing data.

Due to the use of seeks (via lseek) in rawspec, it can't handle FIFOs as an input in the current version. This PR introduces an alternative code path where rawspec will detect if the input is a FIFO or PIPE, and now either
- Read only the data required from FIFOs, rather than reading and reverse seeking (in rawspec_raw_read_header)
- Read data from FIFOs into a discard buffer to seek into the future (for handling schan, in main)

To achieve the latter, I've created a new function, read_to_skip based on calls to read_fully, this has an 8k buffer that it repeatedly reads data into until the requested data has been consumed. [I tried benchmarking a few options for the output array](https://gist.github.com/David-McKenna/a5447377c87c902bcd8ab17aa6267f5d) (the array of constant length, a variable length array and a malloc'd array) and found the fixed 8k array was the best option (VLA was faster in some cases, but segfaulted for larger read lengths).

I've tried to follow your coding style and approach while implementing this, but let me know if you want anything changed or if there's way you feel I could improve the implementation.

Cheers,
David