### PR TITLE
INVALID, IGNORE: Sigproc output: shift fch1 to the centre of the top channel, rather than the top of the channel

### DIFF
--- a/rawspec.c
+++ b/rawspec.c
@@ -589,7 +589,8 @@ char tmp[16];
           cb_data[i].fb_hdr.fch1 = raw_hdr.obsfreq
             - raw_hdr.obsbw*((raw_hdr.obsnchan/raw_hdr.nants)-1)
                 /(2*raw_hdr.obsnchan/raw_hdr.nants)
-            - (ctx.Nts[i]/2) * cb_data[i].fb_hdr.foff
+            - (ctx.Nts[i]/2) * cb_data[i].fb_hdr.foff // Shift to the top of the top channel
+            + cb_data[i].fb_hdr.foff / 2 // Account for the shift to the centre of the top channel
             + (schan % (raw_hdr.obsnchan/raw_hdr.nants)) * // Adjust for schan
                 raw_hdr.obsbw / (raw_hdr.obsnchan/raw_hdr.nants);
           cb_data[i].fb_hdr.nchans = ctx.Nc * ctx.Nts[i];


### PR DESCRIPTION
This PR was written with a flawed understanding of the channelisation process of PFBs, and is incorrect as a result. The current implementation is accurate.

~~Hey Dave,~~

~~Someone spotted an issue with the rawspec outputs when comparing our high spectral and high spatial resolution filterbanks from LOFAR. If I run a test output with two different channelisation factors,~~

```shell
rawspec -t 16,16 -f 1024,8 debug_stem
```

~~and then look at the two output files, they both have the same value for fch1. Here's sigproc's `header` command run on the 1024x channelised filterbank,~~
```
Data file                        : debug_stem.rawspec.0000.fil
...
Frequency of channel 1 (MHz)     : 109.960938
Channel bandwidth      (MHz)     : 0.000191
Number of channels               : 420864
```
~~and 8x channelised filterbank,~~
```
Data file                        : debug_stem.rawspec.0001.fil
...
Frequency of channel 1 (MHz)     : 109.960938
Channel bandwidth      (MHz)     : 0.024414
Number of channels               : 3288

```

~~fch1 should refer to the centre of the top frequency channel, not the top of the frequency channel as is the case here. This will cause small frequency-relative errors for the high spectral resolution outputs, and incorrect DM calculations in high time resolution outputs.~~

~~All that is required as a fix here is a 0.5 * output_foff shift in the top value. Here's a look at the output filterbanks of the same command above, but for this patched version. 1024x channelisation,~~

```
Data file                        : debug_stem2.rawspec.0000.fil
...
Frequency of channel 1 (MHz)     : 109.961033
Channel bandwidth      (MHz)     : 0.000191
Number of channels               : 420864
```

~~8x channelisation,~~

```
Data file                        : debug_stem2.rawspec.0001.fil
...
Frequency of channel 1 (MHz)     : 109.973145
Channel bandwidth      (MHz)     : 0.024414
Number of channels               : 3288
```

~~Let me know if you want anything changed here. I'll note that I haven't validated the case where we have a negative bandwidth as I'm short on time, but in theory it should be fine given I'm just using the opposite sign to the original channel offset.~~

~~Cheers,~~
~~David~~