### PR TITLE
V2.4.2 as is at ATA-SETI (4bit mode, split-output-by-antenna, LOAD_TEXTURE_WIDTH suggestion prints)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-PREFIX = /usr/local
+# PREFIX = /usr/local
+PREFIX = /opt/mnt
 BINDIR = $(PREFIX)/bin
 INCDIR = $(PREFIX)/include
 LIBDIR = $(PREFIX)/lib
 DATADIR = $(PREFIX)/share
 
-CUDA_DIR ?= /usr/local/cuda-8.0
+CUDA_DIR ?= $(CUDA_ROOT)
 CUDA_PATH ?= $(CUDA_DIR)
 
 CC=gcc

--- a/rawspec.c
+++ b/rawspec.c
@@ -948,7 +948,7 @@ char tmp[16];
     // Close output files
     if(output_mode == RAWSPEC_FILE) {
       for(i=0; i<ctx.No; i++) {
-        for(j=0; j<cb_data[i].Nant; j++) {
+        for(j=0; j < (cb_data[i].per_ant_out ? cb_data[i].Nant : 1); j++) {
           if(cb_data[i].fd[j] != -1) {
             close(cb_data[i].fd[j]);
             cb_data[i].fd[j] = -1;

--- a/rawspec_callback.h
+++ b/rawspec_callback.h
@@ -5,8 +5,10 @@
 #include "rawspec_fbutils.h"
 
 typedef struct {
-  int fd; // Output file descriptor or socket
+  int *fd; // Output file descriptors (one for each antenna) or socket (at most 1)
   int fd_ics; // Output file descriptor or socket
+  unsigned int Nant; // Number of antenna, splitting Nf per fd
+  char per_ant_out; // Flag to account for Nant
   unsigned int total_spectra;
   unsigned int total_packets;
   unsigned int total_bytes;
@@ -23,7 +25,6 @@ typedef struct {
   float * h_icsbuf;
   unsigned int Nds;
   unsigned int Nf; // Number of fine channels (== Nc*Nts[i])
-  unsigned int Nant;
   // Filterbank header
   fb_hdr_t fb_hdr;
 } callback_data_t;

--- a/rawspec_file.c
+++ b/rawspec_file.c
@@ -6,7 +6,6 @@
 #include <fcntl.h>
 
 #include "rawspec_file.h"
-#include "rawspec_callback.h"
 
 int open_output_file(const char * dest, const char *stem, int output_idx)
 {
@@ -39,13 +38,64 @@ int open_output_file(const char * dest, const char *stem, int output_idx)
   return fd;
 }
 
+int open_output_file_per_antenna_and_write_header(callback_data_t *cb_data, const char * dest, const char *stem, int output_idx)
+{
+  char ant_stem[PATH_MAX+1];
+  if(cb_data->per_ant_out){
+    cb_data->fb_hdr.nchans /= cb_data->Nant;
+  }
+  for(int i = 0; i < (cb_data->per_ant_out ? cb_data->Nant : 1); i++){
+    if(cb_data->per_ant_out){
+      snprintf(ant_stem, PATH_MAX, "%s-ant%03d", stem, i);
+    }
+    else{
+      snprintf(ant_stem, PATH_MAX, "%s", stem);
+    }
+
+    cb_data->fd[i] = open_output_file(dest, ant_stem, output_idx);
+    if(cb_data->fd[i] == -1) {
+      // If we can't open this output file, we probably won't be able to
+      // open any more output files, so print message and bail out.
+      fprintf(stderr, "cannot open output file, giving up\n");
+      return 1; // Give up
+    }
+
+    // Write filterbank header to output file
+    fb_fd_write_header(cb_data->fd[i], &cb_data->fb_hdr);
+  }
+  if(cb_data->per_ant_out){
+    cb_data->fb_hdr.nchans *= cb_data->Nant;
+  }
+  return 0;
+}
+
 void * dump_file_thread_func(void *arg)
 {
   callback_data_t * cb_data = (callback_data_t *)arg;
 
   if(cb_data->fd && cb_data->h_pwrbuf){
-    write(cb_data->fd, cb_data->h_pwrbuf, cb_data->h_pwrbuf_size);
+    if(cb_data->per_ant_out){
+      size_t spectra_stride = cb_data->h_pwrbuf_size / (cb_data->Nds * sizeof(float));
+      size_t pol_stride = spectra_stride / cb_data->fb_hdr.nifs;
+      size_t ant_stride = pol_stride / cb_data->Nant;
+
+      for(size_t k = 0; k < cb_data->Nds; k++){// Spectra out
+        for(size_t j = 0; j < cb_data->fb_hdr.nifs; j++){// Npolout
+          for(size_t i = 0; i < cb_data->Nant; i++){ 
+            if(cb_data->fd[i] == -1){
+              // Assume that the following file-descriptors aren't valid
+              break;
+            }
+            write(cb_data->fd[i], cb_data->h_pwrbuf + i * ant_stride + j * pol_stride + k * spectra_stride, ant_stride * sizeof(float));
+          }
+        }
+      }
+    }
+    else{
+      write(cb_data->fd[0], cb_data->h_pwrbuf, cb_data->h_pwrbuf_size);
+    }
   }
+  
   if(cb_data->fd_ics && cb_data->h_icsbuf){
     write(cb_data->fd_ics, cb_data->h_icsbuf, cb_data->h_pwrbuf_size/cb_data->Nant);
   }

--- a/rawspec_file.h
+++ b/rawspec_file.h
@@ -2,12 +2,15 @@
 #define _RAWSPEC_FILE_H_
 
 #include "rawspec.h"
+#include "rawspec_callback.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 int open_output_file(const char * dest, const char *stem, int output_idx);
+
+int open_output_file_per_antenna_and_write_header(callback_data_t *cb_data, const char * dest, const char *stem, int output_idx);
 
 void dump_file_callback(
     rawspec_context * ctx, int output_product, int callback_type);

--- a/rawspec_gpu.cu
+++ b/rawspec_gpu.cu
@@ -8,6 +8,9 @@
 #define NO_PLAN   ((cufftHandle)-1)
 #define NO_STREAM ((cudaStream_t)-1)
 
+#define LOAD_TEXTURE_WIDTH_POWER 15
+#define LOAD_TEXTURE_WIDTH_MASK (unsigned int)((1<<LOAD_TEXTURE_WIDTH_POWER)-1)
+
 #define MIN(a,b) ((a < b) ? (a) : (b))
 
 #define PRINT_ERRMSG(error)                  \
@@ -125,8 +128,8 @@ __device__ cufftComplex load_callback(void *p_v_in,
   // the polarization offset by subtracting p_v_user from p_v_in and add it to
   // offset.
   offset += (cufftComplex *)p_v_in - (cufftComplex *)p_v_user;
-  c.x = tex2D<float>(d_tex_obj, ((2*offset  ) & 0x7fff), ((  offset  ) >> 14));
-  c.y = tex2D<float>(d_tex_obj, ((2*offset+1) & 0x7fff), ((2*offset+1) >> 15));
+  c.x = tex2D<float>(d_tex_obj, ((2*offset  ) & LOAD_TEXTURE_WIDTH_MASK), ((  offset  ) >> (LOAD_TEXTURE_WIDTH_POWER-1)));
+  c.y = tex2D<float>(d_tex_obj, ((2*offset+1) & LOAD_TEXTURE_WIDTH_MASK), ((2*offset+1) >> LOAD_TEXTURE_WIDTH_POWER));
   return c;
 }
 
@@ -407,7 +410,7 @@ int rawspec_initialize(rawspec_context * ctx)
   // A simple bool-flag for now, but could rather hold expansion ratio
   // ^^ would require appropriate changes in rawspec.c (see expand4bps_to8bps)
   char NbpsIsExpanded = 0;
-  size_t buf_size;
+  uint64_t buf_size;
   size_t work_size = 0;
   store_cb_data_t h_scb_data;
   cudaError_t cuda_rc;
@@ -703,13 +706,14 @@ int rawspec_initialize(rawspec_context * ctx)
   // Allocate buffers
 
   // FFT input buffer
-  // The input buffer is padded to the next multiple of 32KB to facilitate 2D
-  // texture lookups by treating the input buffer as a 2D array that is 32KB
-  // wide.
-  buf_size = ctx->Nb*ctx->Ntpb*ctx->Np*ctx->Nc* 2/*complex*/ *(ctx->Nbps/8);
-  if((buf_size & 0x7fff) != 0) {
-    // Round up to next multiple of 32KB
-    buf_size = (buf_size & ~0x7fff) + 0x8000;
+  // The input buffer is padded to the next multiple of 1<<LOAD_TEXTURE_WIDTH_POWER
+  // to facilitate 2D texture lookups by treating the input buffer as a 2D array
+  // that is 1<<LOAD_TEXTURE_WIDTH_POWER wide.
+  buf_size = ctx->Nb*ctx->Ntpb;
+  buf_size *= ctx->Np*ctx->Nc* 2/*complex*/ *(ctx->Nbps/8);
+  if((buf_size & LOAD_TEXTURE_WIDTH_MASK) != 0) {
+    // Round up to next multiple of 64KB
+    buf_size = (buf_size & ~LOAD_TEXTURE_WIDTH_MASK) + 1<<LOAD_TEXTURE_WIDTH_POWER;
   }
 
 #ifdef VERBOSE_ALLOC
@@ -730,9 +734,9 @@ int rawspec_initialize(rawspec_context * ctx)
   res_desc.res.pitch2D.devPtr = gpu_ctx->d_fft_in;
   res_desc.res.pitch2D.desc.f = cudaChannelFormatKindSigned;
   res_desc.res.pitch2D.desc.x = ctx->Nbps; // bits per sample
-  res_desc.res.pitch2D.width = 1<<15;         // elements
-  res_desc.res.pitch2D.height = buf_size>>15; // elements
-  res_desc.res.pitch2D.pitchInBytes = (1<<15) * (ctx->Nbps/8);  // bytes!
+  res_desc.res.pitch2D.width = 1<<LOAD_TEXTURE_WIDTH_POWER;         // elements
+  res_desc.res.pitch2D.height = buf_size>>LOAD_TEXTURE_WIDTH_POWER; // elements
+  res_desc.res.pitch2D.pitchInBytes = (1<<LOAD_TEXTURE_WIDTH_POWER) * (ctx->Nbps/8);  // bytes!
   // tex_desc describes texture mapping
   memset(&tex_desc, 0, sizeof(tex_desc));
 #if 0 // These settings are not used in online examples involved cudaReadModeNormalizedFloat

--- a/rawspec_socket.c
+++ b/rawspec_socket.c
@@ -239,14 +239,14 @@ void * dump_net_thread_func(void *arg)
       total_packets++;
       pkt_size = ppkt - pkt;
       total_bytes += pkt_size;
-      if(send(cb_data->fd, pkt, pkt_size, 0) == -1) {
+      if(send(cb_data->fd[0], pkt, pkt_size, 0) == -1) {
         if(errno == ENOTCONN) {
           // ENOTCONN means that there is no listener on the receive side.
           // Eventually we might want to stop sending packets if there is
           // no remote listener, but for now we try to send packet again
           // in case the remote side is capturing packets with packet sockets
           // (e.g. hashpipe or libpcap/tcpdump).
-          if(send(cb_data->fd, pkt, pkt_size, 0) == -1) {
+          if(send(cb_data->fd[0], pkt, pkt_size, 0) == -1) {
             error_packets++;
           }
         }


### PR DESCRIPTION
This is the production version of rawspec at the ATA-SETI operation.

Finishes the merging in of my prior work on 4bit capability, a split-ant output related option, and a single line definition of the LOAD_TEXTURE_WIDTH as a well as some hints that get printed when the device's limits are reached.