### PR TITLE
Loop through channel in chunks to lessen device memory usage

### DIFF
--- a/rawspec.c
+++ b/rawspec.c
@@ -61,6 +61,7 @@ ssize_t read_fully(int fd, void * buf, size_t bytes_to_read)
 
 static struct option long_opts[] = {
   {"ant",     1, NULL, 'a'},
+  {"batch",   0, NULL, 'b'},
   {"dest",    1, NULL, 'd'},
   {"ffts",    1, NULL, 'f'},
   {"gpu",     1, NULL, 'g'},
@@ -91,6 +92,7 @@ void usage(const char *argv0) {
     "\n"
     "Options:\n"
     "  -a, --ant=ANT          The 0-indexed antenna to exclusively process [-1]\n"
+    "  -b, --batch=BC         Batch process BC coarse-channels at a time (1: auto, <1: disabled) [0]\n"
     "  -d, --dest=DEST        Destination directory or host:port\n"
     "  -f, --ffts=N1[,N2...]  FFT lengths [1048576, 8, 1024]\n"
     "  -g, --GPU=IDX          Select GPU device to use [0]\n"
@@ -204,7 +206,7 @@ char tmp[16];
 
   // Parse command line.
   argv0 = argv[0];
-  while((opt=getopt_long(argc,argv,"a:d:f:g:HI:i:n:o:p:r:Ss:t:hv",long_opts,NULL))!=-1) {
+  while((opt=getopt_long(argc,argv,"a:b:d:f:g:HI:i:n:o:p:r:Ss:t:hv",long_opts,NULL))!=-1) {
     switch (opt) {
       case 'h': // Help
         usage(argv0);
@@ -213,6 +215,10 @@ char tmp[16];
 
       case 'a': // Antenna selection to process
         ant = strtol(optarg, NULL, 0);
+        break;
+
+      case 'b': // Batch-channels
+        ctx.Nbc = strtol(optarg, NULL, 0);
         break;
 
       case 'd': // Output destination
@@ -346,8 +352,6 @@ char tmp[16];
     usage(argv0);
     return 1;
   }
-
-  ctx.Nbc = 1;
 
   // Show librawspec version on startup
   printf("rawspec using librawspec %s\n", rawspec_version_string());

--- a/rawspec.c
+++ b/rawspec.c
@@ -849,13 +849,7 @@ char tmp[16];
               fprintf(stderr, "\n");
 #endif // VERBOSE
               rawspec_wait_for_completion(&ctx);
-              if(expand4bps_to8bps){
-                rawspec_copy_blocks_to_gpu_expanding_complex4(&ctx, 0, 0, ctx.Nb);
-              }
-              else{
-                rawspec_copy_blocks_to_gpu(&ctx, 0, 0, ctx.Nb);
-              }
-              rawspec_start_processing(&ctx, RAWSPEC_FORWARD_FFT);
+              rawspec_copy_blocks_to_gpu_and_start_processing(&ctx, ctx.Nb, expand4bps_to8bps, RAWSPEC_FORWARD_FFT);
             }
 
             // Increment block counter
@@ -903,13 +897,7 @@ char tmp[16];
           fprintf(stderr, "\n");
 #endif // VERBOSE
           rawspec_wait_for_completion(&ctx);
-          if(expand4bps_to8bps){
-            rawspec_copy_blocks_to_gpu_expanding_complex4(&ctx, 0, 0, ctx.Nb);
-          }
-          else{
-            rawspec_copy_blocks_to_gpu(&ctx, 0, 0, ctx.Nb);
-          }
-          rawspec_start_processing(&ctx, RAWSPEC_FORWARD_FFT);
+          rawspec_copy_blocks_to_gpu_and_start_processing(&ctx, ctx.Nb, expand4bps_to8bps, RAWSPEC_FORWARD_FFT);
         }
 
         // Remember pktidx

--- a/rawspec.c
+++ b/rawspec.c
@@ -347,6 +347,8 @@ char tmp[16];
     return 1;
   }
 
+  ctx.Ncc = 1;
+
   // Show librawspec version on startup
   printf("rawspec using librawspec %s\n", rawspec_version_string());
 

--- a/rawspec.c
+++ b/rawspec.c
@@ -347,7 +347,7 @@ char tmp[16];
     return 1;
   }
 
-  ctx.Ncc = 1;
+  ctx.Nbc = 1;
 
   // Show librawspec version on startup
   printf("rawspec using librawspec %s\n", rawspec_version_string());

--- a/rawspec.h
+++ b/rawspec.h
@@ -39,7 +39,7 @@ struct rawspec_context_s {
   // In order to better manage device memory usage, chunks of channels are
   // processed at a time, instead of all channels. A value of 0 acts as a 
   // negative flag within the initialisation function.
-  unsigned int Ncc;  // Number of coarse channels in a chunk (Chunk-Channels)
+  unsigned int Nbc;  // Number of coarse channels per batch (Batched-Channels)
 
   // Nbps is the number of bits per sample (per component).  The only supported
   // values are 4* or 8 or 16.  Illegal values will be treated as 8.

--- a/rawspec.h
+++ b/rawspec.h
@@ -208,6 +208,10 @@ int rawspec_zero_blocks_to_gpu(rawspec_context * ctx,
 // `rawspec_wait_for_completion` returns 0.
 int rawspec_start_processing(rawspec_context * ctx, int fft_dir);
 
+// Calls the appropriate rawspec_copy_blocks_to_gpu(), and then 
+// rawspec_start_processing.
+int rawspec_copy_blocks_to_gpu_and_start_processing(rawspec_context * ctx, size_t num_blocks, char expand4bps_to8bps, int fft_dir);
+
 // Waits for any processing to finish, then clears output power buffers and
 // resets inbuf_count to 0.  Returns 0 on success, non-zero on error.
 int rawspec_reset_integration(rawspec_context * ctx);

--- a/rawspec.h
+++ b/rawspec.h
@@ -36,6 +36,11 @@ struct rawspec_context_s {
   unsigned int Nc;    // Number of coarse channels
   unsigned int Ntpb;  // Number of time samples per block
 
+  // In order to better manage device memory usage, chunks of channels are
+  // processed at a time, instead of all channels. A value of 0 acts as a 
+  // negative flag within the initialisation function.
+  unsigned int Ncc;  // Number of coarse channels in a chunk (Chunk-Channels)
+
   // Nbps is the number of bits per sample (per component).  The only supported
   // values are 4* or 8 or 16.  Illegal values will be treated as 8.
   // 4 bits per sample (assumed to be paired as an 8bit complex byte, the most

--- a/rawspec_gpu.cu
+++ b/rawspec_gpu.cu
@@ -607,7 +607,7 @@ int rawspec_initialize(rawspec_context * ctx)
         }
       }
     }
-    else if(ctx->Nc%ctx->Nbc != 0) { // Manual channel-batching, but inappropriate batches
+    if(ctx->Nc%ctx->Nbc != 0) { // inappropriate batches, probably Manual channel-batching
       fprintf(stderr, "%d channels cannot be factorised to batches of %d\n",
         ctx->Nc, ctx->Nbc
       );

--- a/rawspec_gpu.cu
+++ b/rawspec_gpu.cu
@@ -590,7 +590,14 @@ int rawspec_initialize(rawspec_context * ctx)
           }
         }
       }
-    }//else manual channel-chunking
+    }
+    else if(ctx->Nc%ctx->Ncc != 0) { // Manual channel-chunking, but inappropriate chunks
+      fprintf(stderr, "%d channels cannot be factorised to chunks of %d\n",
+        ctx->Nc, ctx->Ncc
+      );
+      return 1;
+    }
+
     printf("Chunking %d channels into %d chunks of %d.\n", ctx->Nc, ctx->Nc/ctx->Ncc, ctx->Ncc);
   }
 

--- a/rawspec_gpu.cu
+++ b/rawspec_gpu.cu
@@ -580,9 +580,18 @@ int rawspec_initialize(rawspec_context * ctx)
   }
   else{ // Enabled channel-chunking
     if(ctx->Ncc <= 1) { // Auto channel-chunking
-      ctx->Ncc = ctx->Nc/ctx->Nant;
+      if(ctx->Nant > 1){
+        ctx->Ncc = ctx->Nc/ctx->Nant;
+      }
+      else{ // find largest Nc factor <= 10
+        for(i = 1; i <= 10; i++){
+          if(ctx->Nc%i == 0){
+            ctx->Ncc = ctx->Nc/i;
+          }
+        }
+      }
     }//else manual channel-chunking
-    printf("Chunking %d channels into %d chunks of %d.\n", ctx->Nc, ctx->Nant, ctx->Ncc);
+    printf("Chunking %d channels into %d chunks of %d.\n", ctx->Nc, ctx->Nc/ctx->Ncc, ctx->Ncc);
   }
 
   // Null out all pointers

--- a/rawspec_gpu.cu
+++ b/rawspec_gpu.cu
@@ -1583,6 +1583,17 @@ int rawspec_start_processing(rawspec_context * ctx, int fft_dir)
   return 0;
 }
 
+int rawspec_copy_blocks_to_gpu_and_start_processing(rawspec_context * ctx, size_t num_blocks, char expand4bps_to8bps, int fft_dir)
+{
+  if(expand4bps_to8bps){
+    rawspec_copy_blocks_to_gpu_expanding_complex4(ctx, 0, 0, num_blocks);
+  }
+  else{
+    rawspec_copy_blocks_to_gpu(ctx, 0, 0, num_blocks);
+  }
+  return rawspec_start_processing(ctx, fft_dir);
+}
+
 // Waits for any processing to finish, then clears output power buffers and
 // resets inbuf_count to 0.  Returns 0 on success, non-zero on error.
 int rawspec_reset_integration(rawspec_context * ctx)

--- a/rawspec_gpu.cu
+++ b/rawspec_gpu.cu
@@ -5,8 +5,6 @@
 #include <cufftXt.h>
 #include <helper_cuda.h>
 
-#define VERBOSE_ALLOC
-
 #define NO_PLAN   ((cufftHandle)-1)
 #define NO_STREAM ((cudaStream_t)-1)
 

--- a/rawspec_gpu.cu
+++ b/rawspec_gpu.cu
@@ -573,14 +573,17 @@ int rawspec_initialize(rawspec_context * ctx)
     }
   }
 
+  ctx->Nant = ctx->Nant <= 0 ? 1 : ctx->Nant;
   // Setup channel-chunk parametners
   if(ctx->Ncc == 0) { // Disable channel-chunking
     ctx->Ncc = ctx->Nc;
   }
-  else if(ctx->Ncc <= 1) { // Auto channel-chunking
-    ctx->Ncc = ctx->Nc/ctx->Nant;
+  else{ // Enabled channel-chunking
+    if(ctx->Ncc <= 1) { // Auto channel-chunking
+      ctx->Ncc = ctx->Nc/ctx->Nant;
+    }//else manual channel-chunking
     printf("Chunking %d channels into %d chunks of %d.\n", ctx->Nc, ctx->Nant, ctx->Ncc);
-  }//else manual channel-chunking
+  }
 
   // Null out all pointers
   // TODO Add support for client managed host buffers

--- a/rawspectest.c
+++ b/rawspectest.c
@@ -35,7 +35,7 @@ int main(int argc, char * argv[])
   ctx.No = 4;
   ctx.Np = 2;
   ctx.Nc = 88;
-  ctx.Ncc = 1;
+  ctx.Nbc = 1;
   ctx.Nbps = 8;
   if(argc > 1) {
     ctx.Nbps = strtoul(argv[1], NULL, 0);

--- a/rawspectest.c
+++ b/rawspectest.c
@@ -35,6 +35,7 @@ int main(int argc, char * argv[])
   ctx.No = 4;
   ctx.Np = 2;
   ctx.Nc = 88;
+  ctx.Ncc = 1;
   ctx.Nbps = 8;
   if(argc > 1) {
     ctx.Nbps = strtoul(argv[1], NULL, 0);


### PR DESCRIPTION
This is built on the work in PR #21, it will remain a draft until that is merged.
------------------------------------------------------------------------------------

This breaks `Nc` into a number of channel-chunks, `Ncc`. The low-hanging fruit were tackled first to get this up and running:

Currently (1) host side buffers (`h_blkbuf` RAW blocks read, and `h_pwrbuf` power spectra write) and (2) the device side `d_fft_in` buffer, are still full size (for `Nc` channels).
1) because host side typically has ample RAM, bu
2) because the h->d transfer is the most sequential bottleneck, so do it in one go (for now)

The (3) device side `d_fft_out` and `d_pwr_out` buffers are sized for `Ncc` channels, so `Nc/Ncc` executions of the `load->fft->store` plan are executed (in parallel AFAIK).

For now `Ncc` is determined by the rawspec_initialise(), based on its initial, user-defined value:
```
if Ncc == 0: //disabled
  Ncc = Nc
elif Ncc == 1: //auto
  Ncc = Nc/Nant
// else: //manual
```

No CLI argument exposure has been set up, yet.

-----------------------------------------------------

(1) and (2) could definitely be tackled, but (3) alone proved sufficient to reduce the device memory usage of a 262144 FFT of 5 antennae worth of 1280 channels each (6400 total channels) down from ~45 GB to < 17 GB **WITH NO EVIDENT PERFORMANCE HIT**.