### PR TITLE
Rawspec adjust -S and -i (remove -I) #34

### DIFF
--- a/rawspec.c
+++ b/rawspec.c
@@ -65,7 +65,6 @@ static struct option long_opts[] = {
   {"ffts",    1, NULL, 'f'},
   {"gpu",     1, NULL, 'g'},
   {"hdrs",    0, NULL, 'H'},
-  {"ics",     1, NULL, 'i'},
   {"ICS",     1, NULL, 'I'},
   {"nchan",   1, NULL, 'n'},
   {"outidx",  1, NULL, 'o'},
@@ -95,7 +94,7 @@ void usage(const char *argv0) {
     "  -f, --ffts=N1[,N2...]  FFT lengths [1048576, 8, 1024]\n"
     "  -g, --GPU=IDX          Select GPU device to use [0]\n"
     "  -H, --hdrs             Save headers to separate file\n"
-    "  -i, --ics=W1[,W2...]   Output incoherent-sum concurrently (capitilise for exclusively),\n"
+    "  -i, --ics=W1[,W2...]   Output incoherent-sum (exclusively, unless with -S)\n"
     "                         specifying per antenna-weights or a singular, uniform weight\n"
     "  -n, --nchan=N          Number of coarse channels to process [all]\n"
     "  -o, --outidx=N         First index number for output files [0]\n"
@@ -253,9 +252,8 @@ char tmp[16];
         save_headers = 1;
         break;
 
-      case 'I': // Incoherently sum exclusively
+      case 'i': // Incoherently sum exclusively
         only_output_ics = 1;
-      case 'i': // Incoherently sum
         ctx.incoherently_sum = 1;
         ctx.Naws = 1;
         // Count number of 
@@ -332,6 +330,8 @@ char tmp[16];
 
       case '?': // Command line parsing error
       default:
+        printf("Unknown CLI option '%c'\n", opt);
+        usage(argv0);
         return 1;
         break;
     }
@@ -552,6 +552,10 @@ char tmp[16];
         fprintf(stderr, "OBSBW    = %g\n",  raw_hdr.obsbw);
         fprintf(stderr, "TBIN     = %g\n",  raw_hdr.tbin);
 #endif // VERBOSE
+        if(raw_hdr.nants > 1 && !(per_ant_out || ctx.incoherently_sum)){
+          printf("NANTS = %d >1: Enabling --split-ant in lieu of neither --split-ant nor --ics flags.\n", raw_hdr.nants);
+          per_ant_out = 1;
+        }
 
         // If splitting output per antenna, re-alloc the fd array.
         if(per_ant_out) {
@@ -586,7 +590,7 @@ char tmp[16];
             printf("Ignoring --splitant flag in network mode\n");
           }
           if(only_output_ics){
-            printf("Cancelling exclusive ICS output due to --splitant.\n");
+            printf("Cancelling exclusivity of ICS output due to --splitant.\n");
             only_output_ics = 0;
           }
         }


### PR DESCRIPTION
GUPPI RAW files with NANTS>1 is an informal extension of the file format's specification. The filterbank specification similarly does not have a dimension for antenna/source: filterbank files with more than one antennae's data "cannot be processed successfully by blimpy + turbo_seti" (Richard Elkins).

In light of this, the PR adjusts rawspec to always apply at least one of either `--split-ant` or `--ics` to inputs with NANTS>1. 

This moves the output cases (with an input RAW with NANTS>1) from:

- |-S|-I|-i|  Flag used indicated with 'x', not used with 'o'
- | o| o|o|   output an inappropriate filterbank with more than 1 antennae's data
- | o| o|x|   output an inappropriate filterbank with more than 1 antennae's data, and an ICS filterbank
- | o| x|o|   output an ICS filterbank
- | x| o|o|   output a filterbank per antenna, each appropriate
- | o| x|x|   output an ICS filterbank
- | x| x|o|   output a filterbank per antenna, each appropriate, and an ICS filterbank
- | x| x|x|   output a filterbank per antenna, each appropriate, and an ICS filterbank

To:
- |-S|-i|  Flag used indicated with 'x'
- | o|o|   set the -S flag and output a filterbank per antenna, each appropriate
- | o| x|  output an ICS filterbank
- | x| o|   output a filterbank per antenna, each appropriate
- | x| x|   output a filterbank per antenna, each appropriate, and an ICS filterbank
