### PR TITLE
^ rawspec_file fileext[4]

### DIFF
--- a/rawspec_file.c
+++ b/rawspec_file.c
@@ -17,7 +17,7 @@ int open_output_file(callback_data_t *cb_data, const char * dest, const char *st
   int fd;
   const char * basename;
   char fname[PATH_MAX+1];
-  char fileext[3];
+  char fileext[4] = {'\0'};
   int retcode;
 
   // If dest is given and it's not empty


### PR DESCRIPTION
- in the case of 'fil' extension, space for the termination character is needed

Before this, at the ATA, I was seeing that the destination path was unreasonable:
```
#LD_LIBRARY_PATH=/opt/mnt/lib /opt/mnt/bin/rawspec -f 16384 -t 2 -i 1.0 -z -d /mnt/buf0/rawspec/guppi_59648_71570_80814025_AzEl_0001 /mnt/buf0/dmpauto/GUPPI/guppi_59648_71570_80814025_AzEl_0001 
rawspec 3.1.1+5@g941a91a-dirty using librawspec 3.1.1+5@g941a91a-dirty and cuFFT 10.5.1.100
writing output for incoherent sum over all antennas
writing output files in SIGPROC Filterbank format
working stem: /mnt/buf0/dmpauto/GUPPI/guppi_59648_71570_80814025_AzEl_0001
opening file: /mnt/buf0/dmpauto/GUPPI/guppi_59648_71570_80814025_AzEl_0001.0000.raw
Using the single antenna-weight (1.000000) for all antennas in the incoherent-sum.
output 0 Nds = 1, Nf = 62914560
/mnt/buf0/rawspec/guppi_59648_71570_80814025_AzEl_0001/guppi_59648_71570_80814025_AzEl_0001-ics.rawspec.0000.fil/mnt/buf0/rawspec/guppi_59648_71570_80814025_AzEl_0001/guppi_59648_71570_80814025_AzEl_0001-ics.rawspec.0000.: No such file or directory
cannot open output file, giving up
```