### PR TITLE
Fix case NPOL = 2

### DIFF
--- a/rawspec_rawutils.c
+++ b/rawspec_rawutils.c
@@ -242,6 +242,13 @@ off_t rawspec_raw_read_header(int fd, rawspec_raw_hdr_t * raw_hdr)
   if(raw_hdr->npol == 4) {
     // 2 is the actual number of polarizations present
     raw_hdr->npol = 2;
+  } else if(raw_hdr->npol == 2) {
+    // 1 is the actual number of polarizations present
+    raw_hdr->npol = 1;
+  } else {
+    fprintf(stderr,
+        "NPOL must be either 2 or 4, not %d\n", raw_hdr->npol);
+    return -1;
   }
 
   // Save header pos/size


### PR DESCRIPTION
The case where `NPOL = 2` in the GUPPI header (i.e., when the data is single polarization) was not handled correctly. The number of polarizations would be interpreted as 2 when reading the GUPPI header, causing problems later on.

Here we set the number of polarizations to 1 when `NPOL = 2`. Additionally, we fail if NPOL is not either 2 or 4, since in
`rawspec_initialized()` [it is checked that the number of polarizations is either 1 or 2](https://github.com/UCBerkeleySETI/rawspec/blob/188981a992eb6fddd105dee0d7763b07802fc861/rawspec_gpu.cu#L487). However, an `NPOL = 1` in the header (which is meaningless) would get through and be interpreted as 1 polarization unless we fail in this case.